### PR TITLE
fix for storing ids using scientific notation

### DIFF
--- a/harvest.rb
+++ b/harvest.rb
@@ -55,6 +55,12 @@ TWEET_HEADERS = {:user => 'Username',
 
 TWEET_EXPLODERS = [:user, :uris, :urls, :user_mentions, :hashtags, :media, :quoted_status, :retweeted_status]
 
+TWEET_STRINGIFY_FIELDS = [:id,
+                          :in_reply_to_screen_name,
+                          :in_reply_to_user_id,
+                          :in_reply_to_status_id,
+                          :in_reply_to_tweet_id ]
+
 USER_HEADERS = [:id, :name, :screen_name, :description,
                 :location, :url, :contributors_enabled, :created_at,
                 :default_profile_image, :default_profile, :favourites_count, :followers_count,
@@ -115,7 +121,7 @@ end
 
 def explode(worksheet, tweet, y_index)
   TWEET_HEADERS.each_with_index do |(key, value), x_index|
-    worksheet.add_cell(y_index, x_index, TWEET_EXPLODERS.include?(key) ? exploded_value(tweet, key) : (tweet.send(key).to_s == '[]' ? '' : tweet.send(key)) )
+    worksheet.add_cell(y_index, x_index, TWEET_EXPLODERS.include?(key) ? exploded_value(tweet, key) : typed_value(tweet, key))
   end
 end
 
@@ -128,6 +134,15 @@ def exploded_value(tweet, key)
   return pp_exploded_retweet(tweet) if key == :retweeted_status
   return pp_array(tweet.hashtags) if key == :hashtags
   return pp_attrs_hash(tweet.user_mentions) if key == :user_mentions
+end
+
+def typed_value(tweet, key)
+  val = tweet.send(key)
+  if val.to_s == '[]'
+    ''
+  else
+    TWEET_STRINGIFY_FIELDS.member?(key) ? val.to_s : val
+  end
 end
 
 def workbook.add_user_worksheet(user)


### PR DESCRIPTION
I had this problem in LibreOffice, not sure if it happens in Excel...

Tweet IDs and "In Reply To" IDs were showing up in scientific notation, e.g. "8.26474807927599E+017". If you reformat the cell in LibreOffice to be numeric, the value always shows the last three digits as 000 because there's not enough precision. This corrupts the IDs.

This PR calls #to_s on the relevant fields. (At first, I thought to stringify everything, but I don't think that's desirable for actual numeric values like Number of Retweets, which you may want to run formulas on. Identifiers aren't numbers in any meaningful sense, they just happen to be numeric values.)
